### PR TITLE
Fix screen tone keyword bug

### DIFF
--- a/app.py
+++ b/app.py
@@ -723,7 +723,7 @@ def process_image(params):
             gray_image=gray,
             color=screen_tone_color_2,
             density=screen_tone_density_2,
-            pencil_shading_style=pencil_shading_style_2
+            pencil_style=pencil_shading_style_2
         )
 
     # เก็บภาพที่ประมวลผล


### PR DESCRIPTION
## Summary
- correct argument name when applying second screen tone layer

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684711821da883249e19aa4b128998f3