### PR TITLE
Add initial tests and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# MangaApp
+
+## Running Tests
+
+1. Install dependencies from `requirements.txt` (consider using a virtual environment):
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run the test suite with:
+   ```bash
+   pytest
+   ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ gunicorn
 Pillow
 opencv-python-headless
 numpy
+pytest

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,17 @@
+import json
+import pytest
+from app import app
+
+
+def test_root_get():
+    with app.test_client() as client:
+        resp = client.get('/')
+        assert resp.status_code == 200
+
+
+def test_process_without_image():
+    with app.test_client() as client:
+        resp = client.post('/process', json={})
+        assert resp.status_code == 200
+        assert resp.get_json() == {'status': 'error'}
+


### PR DESCRIPTION
## Summary
- add pytest to requirements
- provide test suite checking main routes
- document test running instructions in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684b3ac3fa0483248c2cd528e3e7ff3b